### PR TITLE
Added logic to expand environment variables in key file path

### DIFF
--- a/KeeAgent/EntrySettings.cs
+++ b/KeeAgent/EntrySettings.cs
@@ -45,12 +45,7 @@ namespace KeeAgent
       {
           get
           {
-              String resolvedFileName = FileName;
-              if (resolvedFileName.StartsWith("~/", StringComparison.Ordinal))
-              {
-                  resolvedFileName = Path.Combine("%HOME%", resolvedFileName.Substring(2));
-              }
-              return Environment.ExpandEnvironmentVariables(resolvedFileName);
+              return ExtensionMethods.ExpandEnvironmentVariables(FileName);
           }
       }
 

--- a/KeeAgent/EntrySettings.cs
+++ b/KeeAgent/EntrySettings.cs
@@ -41,13 +41,6 @@ namespace KeeAgent
       public string AttachmentName { get; set; }
       public bool SaveAttachmentToTempFile { get; set; }
       public string FileName { get; set; }
-      public string ResolvedFileName
-      {
-          get
-          {
-              return ExtensionMethods.ExpandEnvironmentVariables(FileName);
-          }
-      }
 
       public LocationData()
       {

--- a/KeeAgent/EntrySettings.cs
+++ b/KeeAgent/EntrySettings.cs
@@ -20,6 +20,7 @@
 //  along with this program; if not, see <http://www.gnu.org/licenses>
 
 using System;
+using System.IO;
 using System.Xml.Serialization;
 
 namespace KeeAgent
@@ -40,6 +41,18 @@ namespace KeeAgent
       public string AttachmentName { get; set; }
       public bool SaveAttachmentToTempFile { get; set; }
       public string FileName { get; set; }
+      public string ResolvedFileName
+      {
+          get
+          {
+              String resolvedFileName = FileName;
+              if (resolvedFileName.StartsWith("~/", StringComparison.Ordinal))
+              {
+                  resolvedFileName = Path.Combine("%HOME%", resolvedFileName.Substring(2));
+              }
+              return Environment.ExpandEnvironmentVariables(resolvedFileName);
+          }
+      }
 
       public LocationData()
       {

--- a/KeeAgent/ExtensionMethods.cs
+++ b/KeeAgent/ExtensionMethods.cs
@@ -189,8 +189,8 @@ namespace KeeAgent
           return GetSshKey(getPrivateKeyStream, getPublicKeyStream,
                            settings.Location.AttachmentName, getPassphraseCallback);
         case EntrySettings.LocationType.File:
-          getPrivateKeyStream = () => File.OpenRead(settings.Location.FileName);
-          var publicKeyFile = settings.Location.FileName + ".pub";
+          getPrivateKeyStream = () => File.OpenRead(settings.Location.ResolvedFileName);
+          var publicKeyFile = settings.Location.ResolvedFileName + ".pub";
           if (File.Exists(publicKeyFile))
             getPublicKeyStream = () => File.OpenRead(publicKeyFile);
           return GetSshKey(getPrivateKeyStream, getPublicKeyStream,

--- a/KeeAgent/ExtensionMethods.cs
+++ b/KeeAgent/ExtensionMethods.cs
@@ -295,5 +295,19 @@ namespace KeeAgent
         Size = control.Size,
       });
     }
+
+      /// <summary>
+      /// Expand environment variables in a filename. Also expandes ~/ to %HOME% environment variable.
+      /// </summary>
+      /// <param name="path"></param>
+    public static String ExpandEnvironmentVariables(String filename)
+    {      
+        if (filename.StartsWith("~/", StringComparison.Ordinal))
+        {
+            filename = Path.Combine("%HOME%", filename.Substring(2));
+        }
+
+        return Environment.ExpandEnvironmentVariables(filename);
+    }
   }
 }

--- a/KeeAgent/ExtensionMethods.cs
+++ b/KeeAgent/ExtensionMethods.cs
@@ -189,8 +189,8 @@ namespace KeeAgent
           return GetSshKey(getPrivateKeyStream, getPublicKeyStream,
                            settings.Location.AttachmentName, getPassphraseCallback);
         case EntrySettings.LocationType.File:
-          getPrivateKeyStream = () => File.OpenRead(settings.Location.ResolvedFileName);
-          var publicKeyFile = settings.Location.ResolvedFileName + ".pub";
+          getPrivateKeyStream = () => File.OpenRead(settings.Location.FileName.ExpandEnvironmentVariables());
+          var publicKeyFile = settings.Location.FileName.ExpandEnvironmentVariables() + ".pub";
           if (File.Exists(publicKeyFile))
             getPublicKeyStream = () => File.OpenRead(publicKeyFile);
           return GetSshKey(getPrivateKeyStream, getPublicKeyStream,
@@ -300,7 +300,7 @@ namespace KeeAgent
       /// Expand environment variables in a filename. Also expandes ~/ to %HOME% environment variable.
       /// </summary>
       /// <param name="path"></param>
-    public static String ExpandEnvironmentVariables(String filename)
+    public static String ExpandEnvironmentVariables(this String filename)
     {      
         if (filename.StartsWith("~/", StringComparison.Ordinal))
         {

--- a/KeeAgent/KeeAgentExt.cs
+++ b/KeeAgent/KeeAgentExt.cs
@@ -633,7 +633,7 @@ namespace KeeAgent
             case EntrySettings.LocationType.File:
               if (string.IsNullOrWhiteSpace(settings.Location.FileName)) {
                 errorMessage = "Must specify file name";
-              } else if (!File.Exists(settings.Location.FileName)) {
+              } else if (!File.Exists(settings.Location.ResolvedFileName)) {
                 errorMessage = "File does not exist";
               }
               break;

--- a/KeeAgent/KeeAgentExt.cs
+++ b/KeeAgent/KeeAgentExt.cs
@@ -156,11 +156,7 @@ namespace KeeAgent
               unixAgent.ConfirmUserPermissionCallback = Default.ConfirmCallback;
               agent = unixAgent;
               try {
-                var socketPath = Options.UnixSocketPath;
-                if (socketPath.StartsWith("~/", StringComparison.Ordinal)) {
-                  socketPath = Path.Combine("%HOME%", socketPath.Substring (2));
-                }
-                socketPath = Environment.ExpandEnvironmentVariables(socketPath);
+                var socketPath = ExtensionMethods.ExpandEnvironmentVariables(Options.UnixSocketPath);
                 unixAgent.StartUnixSocket (socketPath);
               } catch (ArgumentNullException) {
                 var autoModeMessage = Options.AgentMode == AgentMode.Auto
@@ -304,10 +300,7 @@ namespace KeeAgent
         return;
       try {
         unixAgent.StopUnixSocket();
-        var socketPath = Options.UnixSocketPath;
-        if (socketPath.StartsWith("~/", StringComparison.Ordinal)) {
-          socketPath = Path.Combine("%HOME%", socketPath.Substring (2));
-        }
+        var socketPath = ExtensionMethods.ExpandEnvironmentVariables(Options.UnixSocketPath);
         unixAgent.StartUnixSocket(Environment.ExpandEnvironmentVariables(
           socketPath));
       } catch (Exception ex) {

--- a/KeeAgent/KeeAgentExt.cs
+++ b/KeeAgent/KeeAgentExt.cs
@@ -156,7 +156,7 @@ namespace KeeAgent
               unixAgent.ConfirmUserPermissionCallback = Default.ConfirmCallback;
               agent = unixAgent;
               try {
-                var socketPath = ExtensionMethods.ExpandEnvironmentVariables(Options.UnixSocketPath);
+                var socketPath = Options.UnixSocketPath.ExpandEnvironmentVariables();
                 unixAgent.StartUnixSocket (socketPath);
               } catch (ArgumentNullException) {
                 var autoModeMessage = Options.AgentMode == AgentMode.Auto
@@ -300,7 +300,7 @@ namespace KeeAgent
         return;
       try {
         unixAgent.StopUnixSocket();
-        var socketPath = ExtensionMethods.ExpandEnvironmentVariables(Options.UnixSocketPath);
+        var socketPath = Options.UnixSocketPath.ExpandEnvironmentVariables();
         unixAgent.StartUnixSocket(Environment.ExpandEnvironmentVariables(
           socketPath));
       } catch (Exception ex) {
@@ -626,7 +626,7 @@ namespace KeeAgent
             case EntrySettings.LocationType.File:
               if (string.IsNullOrWhiteSpace(settings.Location.FileName)) {
                 errorMessage = "Must specify file name";
-              } else if (!File.Exists(settings.Location.ResolvedFileName)) {
+              } else if (!File.Exists(settings.Location.FileName.ExpandEnvironmentVariables())) {
                 errorMessage = "File does not exist";
               }
               break;

--- a/KeeAgent/UI/EntryPanel.cs
+++ b/KeeAgent/UI/EntryPanel.cs
@@ -122,7 +122,7 @@ namespace KeeAgent.UI
               string file = "attachment";
               if (keyLocationPanel.KeyLocation.SelectedType == EntrySettings.LocationType.File) {
                 try {
-                  file = Path.GetFullPath(CurrentSettings.Location.ResolvedFileName);
+                  file = Path.GetFullPath(CurrentSettings.Location.FileName.ExpandEnvironmentVariables());
                 } catch (Exception) {
                   file = "file";
                 }

--- a/KeeAgent/UI/EntryPanel.cs
+++ b/KeeAgent/UI/EntryPanel.cs
@@ -122,7 +122,7 @@ namespace KeeAgent.UI
               string file = "attachment";
               if (keyLocationPanel.KeyLocation.SelectedType == EntrySettings.LocationType.File) {
                 try {
-                  file = Path.GetFullPath(CurrentSettings.Location.FileName);
+                  file = Path.GetFullPath(CurrentSettings.Location.ResolvedFileName);
                 } catch (Exception) {
                   file = "file";
                 }


### PR DESCRIPTION
Environment variables were expanded just for the cygwin socket file, so I took that logic and added it to the key file loading, so we can use also Environment Variables in external key files.

Resolves #148 