### PR TITLE
Fix destination constraint view displaying over other controls

### DIFF
--- a/KeeAgent/UI/EntryPanel.cs
+++ b/KeeAgent/UI/EntryPanel.cs
@@ -46,7 +46,6 @@ namespace KeeAgent.UI
         keyInfoGroupBox.Width += xOffset;
         commentTextBox.Width -= 6;
         fingerprintTextBox.Width -= 6;
-        destinationConstraintDataGridView.Anchor = AnchorStyles.Top | AnchorStyles.Left;
       }
     }
 

--- a/KeeAgent/UI/EntryPanel.resx
+++ b/KeeAgent/UI/EntryPanel.resx
@@ -694,7 +694,7 @@
     <value>2</value>
   </data>
   <data name="destinationConstraintDataGridView.Anchor" type="System.Windows.Forms.AnchorStyles, System.Windows.Forms">
-    <value>Top, Bottom, Left, Right</value>
+    <value>Top, Left</value>
   </data>
   <data name="fromHostDataGridViewTextBoxColumn.HeaderText" xml:space="preserve">
     <value>From Host</value>


### PR DESCRIPTION
There was already a fix in place for Mono, this commit generalizes the fix (and removes the explicit Mono handling - I have not yet checked how it looks in Mono now, but I think this should be fine).

Fixes https://github.com/dlech/KeeAgent/issues/351