### PR TITLE
Fix repository URLs for cloning

### DIFF
--- a/HACKING.md
+++ b/HACKING.md
@@ -25,7 +25,7 @@ These are not saved in KeeAgent.csproj, so you have to manually set them up.
 
 * Get the code and open it in Visual Studio Code:
 
-        git clone git://github.com/dlech/KeeAgent
+        git clone git@github.com:dlech/KeeAgent.git
         cd KeeAgent
         nuget restore
         code .
@@ -43,7 +43,7 @@ If `msbuild` is not present, change `tasks.json` to us `xbuild` instead.
 
 * Get the code:
 
-        git clone git://github.com/dlech/KeeAgent
+        git clone git@github.com:dlech/KeeAgent.git
         cd KeeAgent
 
 * Restore the nuget packages:

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: debhelper (>= 10), cli-common-dev (>= 0.8), keepass2 (>= 2.41),
     keepass2-plugin-dev, libchaos-nacl-cil, libbccrypto-cil
 Standards-Version: 4.1.4
 Homepage: http://lechnology.com/KeeAgent
-Vcs-Git: git://github.com/dlech/KeeAgent.git
+Vcs-Git: git@github.com:dlech/KeeAgent.git
 Vcs-Browser: https://github.com/dlech/KeeAgent
 
 Package: keepass2-plugin-keeagent


### PR DESCRIPTION
GitHub has deactivated native git protocol in March 2022 (https://github.blog/changelog/2022-03-15-removed-unencrypted-git-protocol-and-certain-ssh-keys/)