### PR TITLE
Fix typo

### DIFF
--- a/KeeAgent/UI/DecryptProgressDialog.Designer.cs
+++ b/KeeAgent/UI/DecryptProgressDialog.Designer.cs
@@ -63,7 +63,7 @@
             this.ShowInTaskbar = false;
             this.SizeGripStyle = System.Windows.Forms.SizeGripStyle.Hide;
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Decryping SSH Private Key";
+            this.Text = "Decrypting SSH Private Key";
             this.ResumeLayout(false);
 
     }


### PR DESCRIPTION
Fix typo in the decryption dialog name/title.

`Decryping SSH Private Key` to `Decrypting SSH Private Key` (missing `t` in word `Decrypt`)