### PR TITLE
support reading key comment from private key (only openssh do it)

### DIFF
--- a/KeeAgent/UI/EntryPanel.cs
+++ b/KeeAgent/UI/EntryPanel.cs
@@ -135,8 +135,13 @@ namespace KeeAgent.UI
 
       try {
         var key = CurrentSettings.TryGetSshPublicKey(pwEntryForm.EntryBinaries);
+        var comment = key.Comment;
+        if (string.IsNullOrEmpty(comment)) {
+          var privateKey = CurrentSettings.GetSshKey(pwEntryForm.EntryBinaries, pwEntryForm.EntryRef);
+          comment = privateKey.Comment;
+        }
 
-        commentTextBox.Text = key.Comment;
+        commentTextBox.Text = comment;
         fingerprintTextBox.Text = key.Sha256Fingerprint;
         publicKeyTextBox.Text = key.AuthorizedKeysString;
         copyPublicKeyButton.Enabled = true;


### PR DESCRIPTION
Implement openssh key comment support. some add another `GetSshKey` extension method to utilize EntrySettings on KeeAgent tab.

requires https://github.com/dlech/SshAgentLib/pull/23, but this PR doesn't include submodule change (for now).