### PR TITLE
Fix #387 - getting stuck on key usage confirmation

### DIFF
--- a/KeeAgent/KeeAgent.csproj
+++ b/KeeAgent/KeeAgent.csproj
@@ -139,6 +139,7 @@
       <DependentUpon>ManageDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="KeeAgentExt.cs" />
+    <Compile Include="KeeAgentInteractiveUi.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UI\OptionsPanel.cs">
       <SubType>UserControl</SubType>

--- a/KeeAgent/KeeAgent.csproj
+++ b/KeeAgent/KeeAgent.csproj
@@ -139,7 +139,7 @@
       <DependentUpon>ManageDialog.cs</DependentUpon>
     </Compile>
     <Compile Include="KeeAgentExt.cs" />
-    <Compile Include="KeeAgentInteractiveUi.cs" />
+    <Compile Include="KeeAgentUiThread.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UI\OptionsPanel.cs">
       <SubType>UserControl</SubType>

--- a/KeeAgent/KeeAgentExt.cs
+++ b/KeeAgent/KeeAgentExt.cs
@@ -117,7 +117,7 @@ namespace KeeAgent
               // IMPORTANT: if you change either of these callbacks, you need
               // to make sure that they do not block the main event loop.
               pagent.FilterKeyListCallback = FilterKeyList;
-              pagent.ConfirmUserPermissionCallback = Default.ConfirmCallback;
+              pagent.ConfirmUserPermissionCallback = ConfirmUserPermissionCallback;
               agent = pagent;
               if (Options.UseCygwinSocket) {
                 StartCygwinSocket();
@@ -151,7 +151,7 @@ namespace KeeAgent
               // IMPORTANT: if you change either of these callbacks, you need
               // to make sure that they do not block the main event loop.
               unixAgent.FilterKeyListCallback = FilterKeyList;
-              unixAgent.ConfirmUserPermissionCallback = Default.ConfirmCallback;
+              unixAgent.ConfirmUserPermissionCallback = ConfirmUserPermissionCallback;
               agent = unixAgent;
               if (Options.UnixSocketPath == null) {
                 var autoModeMessage = Options.AgentMode == AgentMode.Auto
@@ -207,6 +207,16 @@ namespace KeeAgent
       }
       Terminate();
       return false;
+    }
+
+    private bool ConfirmUserPermissionCallback(ISshKey key, Process process, string user, string fromHost,
+      string toHost)
+    {
+      var result = false;
+      pluginHost.MainWindow.Invoke(new Action(() =>
+        result = Default.ConfirmCallback(key, process, user, fromHost, toHost)
+      ));
+      return result;
     }
 
     public override void Terminate()

--- a/KeeAgent/KeeAgentExt.cs
+++ b/KeeAgent/KeeAgentExt.cs
@@ -42,7 +42,7 @@ namespace KeeAgent
     bool saveBeforeCloseQuestionMessageShown = false;
     Dictionary<string, KeyFileInfo> keyFileMap = new Dictionary<string, KeyFileInfo>();
     KeeAgentColumnProvider columnProvider;
-    KeeAgentInteractiveUi interactiveUi;
+    KeeAgentUiThread _uiThread;
 
     const string pluginNamespace = "KeeAgent";
     const string alwaysConfirmOptionName = pluginNamespace + ".AlwaysConfirm";
@@ -103,7 +103,7 @@ namespace KeeAgent
       var domainSocketPath =
         Environment.GetEnvironmentVariable(UnixClient.SshAuthSockName);
       try {
-        interactiveUi = new KeeAgentInteractiveUi();
+        _uiThread = new KeeAgentUiThread();
         if (Options.AgentMode != AgentMode.Client) {
           if (isWindows) {
             // In windows, try to start an agent. If Pageant is running, we will
@@ -214,7 +214,7 @@ namespace KeeAgent
       string toHost)
     {
       var result = false;
-      interactiveUi.Invoke(() => result = Default.ConfirmCallback(key, process, user, fromHost, toHost));
+      _uiThread.Invoke(() => result = Default.ConfirmCallback(key, process, user, fromHost, toHost));
       return result;
     }
 
@@ -237,8 +237,8 @@ namespace KeeAgent
         agentModeAgent.Dispose();
       }
 
-      if (interactiveUi != null) {
-        interactiveUi.Dispose();
+      if (_uiThread != null) {
+        _uiThread.Dispose();
       }
     }
 
@@ -1241,7 +1241,7 @@ namespace KeeAgent
         return list;
       }
 
-      interactiveUi.Invoke(() => {
+      _uiThread.Invoke(() => {
         //var zIndex = pluginHost.MainWindow.GetZIndex();
         var dialog = new KeyPicker(list);
         dialog.Shown += (sender, e) => dialog.Activate();

--- a/KeeAgent/KeeAgentInteractiveUi.cs
+++ b/KeeAgent/KeeAgentInteractiveUi.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Threading;
+using System.Windows.Forms;
+
+namespace KeeAgent
+{
+  /// <summary>
+  /// Provides a separate UI thread for interactive communication without interlocking with the MainWindow.
+  /// </summary>
+  public sealed class KeeAgentInteractiveUi : IDisposable
+  {
+    private const string ComponentName = "KeeAgent Interactive UI";
+    private SynchronizationContext _synchronizationContext;
+    private ApplicationContext _applicationContext;
+
+    public KeeAgentInteractiveUi()
+    {
+      var uiThread = new Thread(UiThreadMain) {
+        Name = ComponentName,
+        IsBackground = true // active background thread will not block the application shutdown process
+      };
+      uiThread.SetApartmentState(ApartmentState.STA);
+      uiThread.Start();
+    }
+
+    private void UiThreadMain()
+    {
+      var mainForm = new Form {
+        // actually we don't need the window, but there is no other way to capture the SynchronizationContext
+        Name = ComponentName,
+        Text = ComponentName,
+        // some recommendations from https://stackoverflow.com/a/683991
+        FormBorderStyle = FormBorderStyle.FixedToolWindow, // to exclude from appearing in Alt-Tab
+        ShowInTaskbar = false, // to exclude from the Taskbar
+      };
+
+      mainForm.Load += (sender, args) => {
+        // capture SynchronizationContext to send messages to the message loop
+        _synchronizationContext = SynchronizationContext.Current;
+
+        // hide the form... we have to postpone the call, otherwise it stays visible
+        _synchronizationContext.Post(_ => mainForm.Hide(), null);
+      };
+
+      _applicationContext = new ApplicationContext(mainForm);
+      Application.Run(_applicationContext);
+    }
+
+    /// <summary>
+    /// Performs message loop shutdown.
+    /// </summary>
+    public void Dispose()
+    {
+      if (_synchronizationContext == null) {
+        return;
+      }
+
+      var synchronizationContext = _synchronizationContext;
+      _synchronizationContext = null;
+      synchronizationContext.Post(_ => _applicationContext.ExitThread(), null);
+    }
+
+    /// <summary>
+    /// Invokes a delegate on a separate UI Thread, dedicated for the KeeAgent Plugin
+    /// </summary>
+    /// <param name="action">The delegate to call.</param>
+    /// <exception cref="InvalidOperationException">The method was called in while the SynchronizationContext is not
+    /// captured yet or have been disposed already</exception>
+    public void Invoke(Action action)
+    {
+      if (_synchronizationContext == null) {
+        throw new InvalidOperationException(
+          "KeeAgentInteractiveUi: the SynchronizationContext is not captured yet or have been disposed already");
+      }
+
+      _synchronizationContext.Send(_ => action.Invoke(), null);
+    }
+  }
+}

--- a/KeeAgent/KeeAgentUiThread.cs
+++ b/KeeAgent/KeeAgentUiThread.cs
@@ -11,7 +11,6 @@ namespace KeeAgent
   {
     private const string ComponentName = "KeeAgent Interactive UI";
     private SynchronizationContext _synchronizationContext;
-    private ApplicationContext _applicationContext;
 
     public KeeAgentUiThread()
     {
@@ -27,8 +26,7 @@ namespace KeeAgent
     {
       _synchronizationContext = new WindowsFormsSynchronizationContext();
       SynchronizationContext.SetSynchronizationContext(_synchronizationContext);
-      _applicationContext = new ApplicationContext();
-      Application.Run(_applicationContext);
+      Application.Run();
     }
 
     /// <summary>
@@ -42,9 +40,7 @@ namespace KeeAgent
 
       var synchronizationContext = _synchronizationContext;
       _synchronizationContext = null;
-      var applicationContext = _applicationContext;
-      _applicationContext = null;
-      synchronizationContext.Post(_ => applicationContext.ExitThread(), null);
+      synchronizationContext.Post(_ => Application.ExitThread(), null);
     }
 
     /// <summary>


### PR DESCRIPTION
### Abstract

PR is supposed to fix #387 - getting stuck on key usage confirmation.
~~The idea is to marshal the `MessageBox.Show` call to the `MainWindow`'s thread.~~
The idea is to marshal the `MessageBox.Show` and `KeyPicker.ShowDialog` calls to a separate UI thread dedicated to the KeeAgent plugin.

### Problem research

My research didn't show any confirmation on the point that we should marshal `MessageBox` calls to the UI thread, nor that we shouldn't.
A random comment on SO [says](https://stackoverflow.com/a/560028) that `MessageBox` will spin up its own message pump, but I haven't found a confirmation in the documentation.

### Impact analysis

Changes are contained in the KeeAgent library and don't leak to the SshAgentLib.

Possible issue: getting stuck in other situations due to the changes introduced.
I haven't found a situation where the issue will be plausible. Here is my reasoning:

- ~~The only change introduced is marshaling from the `Pageant`'s worker thread to the `MainWindow`'s thread~~
- ~~If the `MainWindow`'s thread is busy, then it is either getting released any time soon or it is stuck already~~
- ~~The `MainWindow`'s thread shouldn't be doing any calls to the `Pageant`'s worker thread, so we are on the safe side of possible dead-locks~~

- The only change introduced is marshaling from the `Pageant`'s worker thread to the UI thread dedicated for the KeeAgent plugin
- If the `KeeAgentUi`'s thread is busy, then it is either getting released any time soon or it is stuck already
- The `KeeAgentUi`'s thread shouldn't be doing any calls to the `Pageant`'s worker thread, so we are on the safe side of possible dead-locks. The work done on the `KeeAgentUi`'s thread is the following:
  - `KeyPicker` dialog during ssh-agent list command
  - `MessageBox` dialog during key usage confirmation

### Reproducibility

I'm not sure this PR fixes the root issue instead of adding one more trick around UI-synchronization problems.
The main reason why I'm not sure is because I can't really reproduce the issue.

The most "valuable" thing I brought from those unsuccessful attempts to reproduce the issue is a screenshot of stuck callstacks. Here it goes:
![Screenshot_32](https://github.com/dlech/KeeAgent/assets/35864862/19c47b26-12b1-4fc3-94ee-d31908252fd7)

It reproduces on my machine if I put the plugin in `C:\Program Files\KeePass Password Safe 2\Plugins` and launch KeePass from program files. Usual behavior: I have a confirmation window on the first SSH attempt, and on the second attempt, I get stuck.

It doesn't reproduce if I launch KeePass from KeeAgent `bin\Debug`. I tried to bump KeePass's version to match the version in program files - but it still doesn't reproduce.

I had some luck reproducing some delays of the MessageBox's appearance when launched from `bin\Debug`. I have two displays. I initiated a git push over ssh on one display, and there were no confirmation windows. When I clicked on the debugger window on the second display, the confirmation window popped up immediately. But that behavior didn't last long. I moved some windows and rearranged the setup to be able to pause the debugger without switching windows, and the behavior had gone.

### Prebuilt plugin to give it a shot

If anyone wants to give it a shot and doesn't have time to build the plugin from sources, here is a prebuilt version:
- ~~[KeeAgent_v0.13.5-fix387.zip](https://github.com/dlech/KeeAgent/files/12795528/KeeAgent_v0.13.5-fix387.zip)~~
- [KeeAgent_v0.13.6-fix387.zip](https://github.com/dlech/KeeAgent/files/13997983/KeeAgent_v0.13.6-fix387.zip)

