### PR TITLE
Fix ignoring expired entries on auto-load using local time

### DIFF
--- a/KeeAgent/KeeAgentExt.cs
+++ b/KeeAgent/KeeAgentExt.cs
@@ -908,6 +908,7 @@ namespace KeeAgent
           return;
         }
 
+        var dtNow = DateTime.UtcNow;
         foreach (var entry in e.Database.RootGroup.GetEntries(true)) {
           if (e.Database.RecycleBinEnabled) {
             var recycleBin = e.Database.RootGroup.FindGroup(e.Database.RecycleBinUuid, true);
@@ -916,7 +917,7 @@ namespace KeeAgent
             }
           }
 
-          if (entry.Expires && entry.ExpiryTime <= DateTime.Now
+          if (entry.Expires && entry.ExpiryTime <= dtNow
             && !e.Database.GetKeeAgentSettings().AllowAutoLoadExpiredEntryKey) {
             continue;
           }

--- a/KeeAgent/UI/EntryPickerDialog.cs
+++ b/KeeAgent/UI/EntryPickerDialog.cs
@@ -84,7 +84,7 @@ namespace KeeAgent.UI
     {
       mCustomTreeViewEx.BeginUpdate();
       mCustomTreeViewEx.Nodes.Clear();
-      mCachedNow = DateTime.Now;
+      mCachedNow = DateTime.UtcNow;
       bool entriesFound = false;
 
       foreach (var db in ext.pluginHost.MainWindow.DocumentManager.GetOpenDatabases()) {


### PR DESCRIPTION
KeePass2 stores `ExpiryTime` in UTC internally.